### PR TITLE
ekleme ve güncelleme işlemlerinde hem optimizasyon sağlamak hemde düz…

### DIFF
--- a/Core/ETicaretAPI.Domain/Entities/Common/BaseEntity.cs
+++ b/Core/ETicaretAPI.Domain/Entities/Common/BaseEntity.cs
@@ -9,6 +9,7 @@ namespace ETicaretAPI.Domain.Entities.Common
     public class BaseEntity //bütün entity lerde kullanılacak ortak Propertyleri tanımlıyorum :  burdan çekecem diğer entitylere = tekrar tekrar yazmamak için
     {
         public Guid Id { get; set; }
-        public DateTime CreateDate { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
     }
 }

--- a/Core/ETicaretAPI.Domain/Entities/Order.cs
+++ b/Core/ETicaretAPI.Domain/Entities/Order.cs
@@ -9,7 +9,7 @@ namespace ETicaretAPI.Domain.Entities
 {
     public class Order : BaseEntity
     {
-        public int CustomerId { get; set; } // entity framwork yapısal olarak : customer burda tekil olduğu için 1- n de : 1 kısmı olduğu için ona Id atıyacak veritabanı alanında otomatik. biz burda eğer bu isimle bunu vermesek zaten kendi veritabanı kısmında yine oluşturur ama biz veritabanındaki değere karşılık bu gelsin diye belirtmek için kendimiz oluşturuyoruz. ismi farklı yapabiliriz. ama o zaman belirmemiz gerekiyormus : belli şekillerde.
+        public Guid CustomerId { get; set; } // entity framwork yapısal olarak : customer burda tekil olduğu için 1- n de : 1 kısmı olduğu için ona Id atıyacak veritabanı alanında otomatik. biz burda eğer bu isimle bunu vermesek zaten kendi veritabanı kısmında yine oluşturur ama biz veritabanındaki değere karşılık bu gelsin diye belirtmek için kendimiz oluşturuyoruz. ismi farklı yapabiliriz. ama o zaman belirmemiz gerekiyormus : belli şekillerde.
         public string Description { get; set; }
         public string Address { get; set; }
 

--- a/Core/ETicaretAPI.Domain/Entities/Product.cs
+++ b/Core/ETicaretAPI.Domain/Entities/Product.cs
@@ -11,7 +11,7 @@ namespace ETicaretAPI.Domain.Entities
     {
         public string Name { get; set; }
         public int Stock { get; set; }
-        public long Price { get; set; }
+        public float Price { get; set; }
         public ICollection<Order> Orders { get; set; } //Productın birden çok orderı olabiliyor. == mantığı order sayfasında entites de açıkladım.
     }
 }

--- a/Infrastructure/ETicaretAPI.Persistence/Contexts/ETicaretAPIDbContext.cs
+++ b/Infrastructure/ETicaretAPI.Persistence/Contexts/ETicaretAPIDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using ETicaretAPI.Domain.Entities;
+using ETicaretAPI.Domain.Entities.Common;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
@@ -17,5 +18,26 @@ namespace ETicaretAPI.Persistence.Contexts //bu classın amacı sql deki tablola
         public DbSet<Product> Products { get; set; } //tablo isimleri defaul olarak burda belirttiğim Products oluyor mesela biz bunu sonradan müdahale ile değiştirebiliyoruz isteğe göre.
         public DbSet<Order> Orders { get; set; }
         public DbSet<Customer> Customers { get; set; }
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) // burada ben değer verilen entityleride değiştirebilirim : verilmeyenlerede atama yapabilirim datalar verilip = güncelleme veya ekleme : savechanges geldikten sonra tetiklenmir burası o yüzden o datalara erişebiliyorum aşşağıda da eriştim zaten.
+            //Burası sayesinde her SaveChanges tetiklendiğinde araya girip istediğim controlleri sağlayacam = interceptor == entityframwork de uyguluyoruz
+            //SaveChanges'in 4 tane methodu vardı buraya ovveride ederken ben default paremetre alanı seçiyorum çünkü writeRepository de onu kullandım.
+        {
+            var datas = ChangeTracker
+                .Entries<BaseEntity>(); // bu yapı sayesinde datas ' a BaseEntity'den gelen verileri yakalıyoruz. BaseEntity de = ortak kullandığımız her tabloda olması gereken datalar
+                // Entityler üzerinden yapılan değişiklerin ya da  yeni eklenen verinin yakalanamasını sağlayan propertydir. Update operasyonlarında Track edilen verileri yakalayıp elde etmemizi sağlar. == tabi track : insert edilen veriyi yakalıyamaz çünkü insert sırasında track kullanılmaz = veritabanından okumalarda track yapısı kullanılıyordu değişikliğ algılamak için.
+
+            foreach(var data in datas)
+            {
+                _ = data.State switch // if yerine kullandık burada == data.State EntityState.Added ise  = EntityState.Added => data.Entity.CreatedDate = DateTime.UtcNow bu işlemi yap ; data.State  = EntityState.Modified buysada  data.Entity.UpdatedDate = DateTime.UtcNow işlemini yap. gibisinden == if 'in farklı bi yöntemi
+                {
+                    EntityState.Added => data.Entity.CreatedDate = DateTime.UtcNow, //ekleme işlemlerinde CreatedDate verilen datayı ata
+                    EntityState.Modified => data.Entity.UpdatedDate = DateTime.UtcNow // güncelleme işlemlerinde UpdatedDate verilen datayı ata.
+                }; //EntityState.Added ; EntityState.Modified kullanımları geriye dönüş sağlıyor biz dönüş ile ilgilenmediğimizden _ = data.State switch dedik geri dönüşü olmasaydı ==  data.State switch demem yeterliydi büyük ihtimal.
+            }
+
+            return await base.SaveChangesAsync(cancellationToken); // methodda task olduğu için meyhoda = async ; buraya await eklemeyi unutmuyoruz
+            // SaveChangesAsync zaten default olarak çalışan o yüzden ben üstte işlemimi yapıp bunun çalışmasına devam etmesine izin verecem.
+        }
     }
 }

--- a/Infrastructure/ETicaretAPI.Persistence/Migrations/20221208224016_mig_1.Designer.cs
+++ b/Infrastructure/ETicaretAPI.Persistence/Migrations/20221208224016_mig_1.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ETicaretAPI.Persistence.Migrations
 {
     [DbContext(typeof(ETicaretAPIDbContext))]
-    [Migration("20221203215844_mig_1")]
+    [Migration("20221208224016_mig_1")]
     partial class mig1
     {
         /// <inheritdoc />
@@ -31,12 +31,15 @@ namespace ETicaretAPI.Persistence.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<DateTime>("CreateDate")
+                    b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("text");
+
+                    b.Property<DateTime>("UpdatedDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -53,22 +56,22 @@ namespace ETicaretAPI.Persistence.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTime>("CreateDate")
+                    b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("CustomerId")
-                        .HasColumnType("integer");
+                    b.Property<Guid>("CustomerId")
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<Guid>("customerId")
-                        .HasColumnType("uuid");
+                    b.Property<DateTime>("UpdatedDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("customerId");
+                    b.HasIndex("CustomerId");
 
                     b.ToTable("Orders");
                 });
@@ -79,18 +82,21 @@ namespace ETicaretAPI.Persistence.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<DateTime>("CreateDate")
+                    b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<long>("Price")
-                        .HasColumnType("bigint");
+                    b.Property<float>("Price")
+                        .HasColumnType("real");
 
                     b.Property<int>("Stock")
                         .HasColumnType("integer");
+
+                    b.Property<DateTime>("UpdatedDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -116,7 +122,7 @@ namespace ETicaretAPI.Persistence.Migrations
                 {
                     b.HasOne("ETicaretAPI.Domain.Entities.Customer", "customer")
                         .WithMany("Orders")
-                        .HasForeignKey("customerId")
+                        .HasForeignKey("CustomerId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 

--- a/Infrastructure/ETicaretAPI.Persistence/Migrations/20221208224016_mig_1.cs
+++ b/Infrastructure/ETicaretAPI.Persistence/Migrations/20221208224016_mig_1.cs
@@ -17,7 +17,8 @@ namespace ETicaretAPI.Persistence.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     Name = table.Column<string>(type: "text", nullable: false),
-                    CreateDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    CreatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -31,8 +32,9 @@ namespace ETicaretAPI.Persistence.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     Name = table.Column<string>(type: "text", nullable: false),
                     Stock = table.Column<int>(type: "integer", nullable: false),
-                    Price = table.Column<long>(type: "bigint", nullable: false),
-                    CreateDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    Price = table.Column<float>(type: "real", nullable: false),
+                    CreatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -44,18 +46,18 @@ namespace ETicaretAPI.Persistence.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    CustomerId = table.Column<int>(type: "integer", nullable: false),
+                    CustomerId = table.Column<Guid>(type: "uuid", nullable: false),
                     Description = table.Column<string>(type: "text", nullable: false),
                     Address = table.Column<string>(type: "text", nullable: false),
-                    customerId = table.Column<Guid>(type: "uuid", nullable: false),
-                    CreateDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    CreatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_Orders", x => x.Id);
                     table.ForeignKey(
-                        name: "FK_Orders_Customers_customerId",
-                        column: x => x.customerId,
+                        name: "FK_Orders_Customers_CustomerId",
+                        column: x => x.CustomerId,
                         principalTable: "Customers",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
@@ -91,9 +93,9 @@ namespace ETicaretAPI.Persistence.Migrations
                 column: "ProductsId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_Orders_customerId",
+                name: "IX_Orders_CustomerId",
                 table: "Orders",
-                column: "customerId");
+                column: "CustomerId");
         }
 
         /// <inheritdoc />

--- a/Infrastructure/ETicaretAPI.Persistence/Migrations/ETicaretAPIDbContextModelSnapshot.cs
+++ b/Infrastructure/ETicaretAPI.Persistence/Migrations/ETicaretAPIDbContextModelSnapshot.cs
@@ -28,12 +28,15 @@ namespace ETicaretAPI.Persistence.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<DateTime>("CreateDate")
+                    b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("text");
+
+                    b.Property<DateTime>("UpdatedDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -50,22 +53,22 @@ namespace ETicaretAPI.Persistence.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTime>("CreateDate")
+                    b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("CustomerId")
-                        .HasColumnType("integer");
+                    b.Property<Guid>("CustomerId")
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<Guid>("customerId")
-                        .HasColumnType("uuid");
+                    b.Property<DateTime>("UpdatedDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("customerId");
+                    b.HasIndex("CustomerId");
 
                     b.ToTable("Orders");
                 });
@@ -76,18 +79,21 @@ namespace ETicaretAPI.Persistence.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<DateTime>("CreateDate")
+                    b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<long>("Price")
-                        .HasColumnType("bigint");
+                    b.Property<float>("Price")
+                        .HasColumnType("real");
 
                     b.Property<int>("Stock")
                         .HasColumnType("integer");
+
+                    b.Property<DateTime>("UpdatedDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -113,7 +119,7 @@ namespace ETicaretAPI.Persistence.Migrations
                 {
                     b.HasOne("ETicaretAPI.Domain.Entities.Customer", "customer")
                         .WithMany("Orders")
-                        .HasForeignKey("customerId")
+                        .HasForeignKey("CustomerId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 

--- a/Infrastructure/ETicaretAPI.Persistence/Repositories/ReadRepository.cs
+++ b/Infrastructure/ETicaretAPI.Persistence/Repositories/ReadRepository.cs
@@ -52,7 +52,7 @@ namespace ETicaretAPI.Persistence.Repositories
             var query = Table.AsQueryable();
             if(!tracking) 
                 query = Table.AsNoTracking();
-            return await query.FirstOrDefaultAsync(data => data.Id == Guid.Parse(id));//query üzerinden çalışırken FindAsync ulaşamadım ondan Mark/işaretleyici yöntemi ile id ye erişim sağlıyacam
+            return await query.FirstOrDefaultAsync(data => data.Id == Guid.Parse(id)); //query üzerinden çalışırken FindAsync ulaşamadım ondan Mark/işaretleyici yöntemi ile id ye erişim sağlıyacam
         }
     }
 }

--- a/Presentation/ETicaretAPI.API/Controllers/ProductsController.cs
+++ b/Presentation/ETicaretAPI.API/Controllers/ProductsController.cs
@@ -10,10 +10,25 @@ namespace ETicaretAPI.API.Controllers
     {
         readonly private IProductWriteRepository _productWriteRepository;
         readonly private IProductReadRepository _productReadRepository;
-        public ProductsController(IProductWriteRepository productWriteRepository, IProductReadRepository productReadRepository)
+
+        readonly private IOrderReadRepository _orderReadRepository;
+        readonly private IOrderWriteRepository _orderWriteRepository;
+
+        readonly private ICustomerReadRepository _customerReadRepository;
+        readonly private ICustomerWriteRepository _customerWriteRepository;
+        public ProductsController(IProductWriteRepository productWriteRepository,
+            IProductReadRepository productReadRepository,
+            IOrderWriteRepository orderWriteRepository,
+            ICustomerWriteRepository customerWriteRepository,
+            IOrderReadRepository orderReadRepository,
+            ICustomerReadRepository customerReadRepository)
         {
             _productWriteRepository = productWriteRepository;
             _productReadRepository = productReadRepository;
+            _orderWriteRepository = orderWriteRepository;
+            _customerWriteRepository = customerWriteRepository;
+            _orderReadRepository = orderReadRepository;
+            _customerReadRepository = customerReadRepository;
         }
 
         [HttpGet]
@@ -21,16 +36,34 @@ namespace ETicaretAPI.API.Controllers
         {
             //await _productWriteRepository.AddRangeAsync(new()
             //{
-               // new() { Id = Guid.NewGuid(), Name = "Product 1", Price = 100, CreateDate = DateTime.UtcNow ,Stock=10},
-               // new() { Id = Guid.NewGuid(), Name = "Product 2", Price = 200, CreateDate = DateTime.UtcNow ,Stock=20},
-               // new() { Id = Guid.NewGuid(), Name = "Product 3", Price = 300, CreateDate = DateTime.UtcNow ,Stock=130},
+            // new() { Id = Guid.NewGuid(), Name = "Product 1", Price = 100, CreateDate = DateTime.UtcNow ,Stock=10},
+            // new() { Id = Guid.NewGuid(), Name = "Product 2", Price = 200, CreateDate = DateTime.UtcNow ,Stock=20},
+            // new() { Id = Guid.NewGuid(), Name = "Product 3", Price = 300, CreateDate = DateTime.UtcNow ,Stock=130},
             //});
             //var count = await _productWriteRepository.SaveAsync();
-
-           Product p = await _productReadRepository.GetByIdAsync("dba02bd2-54a5-49e2-993e-3c87a0e765bb",false); //tracking ile ilgili hiçbir data vermez isem tracking true olacak. == yani takip edecek tracking , false verirsem trackingi takip etmiyecek böylece apide çalıştırdığımda status 200 başarılı sonucu alsamda veritabanında fiziksel bi değişim olmıyacaktır.
+            /*
+           Product p = await _productReadRepository.GetByIdAsync("dba02bd2-54a5-49e2-993e-3c87a0e765bb",false);*/ //tracking ile ilgili hiçbir data vermez isem tracking true olacak. == yani takip edecek tracking , false verirsem trackingi takip etmiyecek böylece apide çalıştırdığımda status 200 başarılı sonucu alsamda veritabanında fiziksel bi değişim olmıyacaktır.
+            /*
             p.Name = "Mehmet";
-            _productWriteRepository.SaveAsync(); // _productReadRepository ile okuduğum veriyi nasıl _productWriteRepository ile yazdırıyorum = depending enjectionda aynı scope kullanıyorlar = bu yüzden _productReadRepository'i kullandığı dbcontext ne ise bunu talep eden _productWriteRepository'de aynı instance'yi elde edecektir. o yüzden biz datayı elde ettiğimiz dbcontext üzerinden SaveAsync() fonksiyonunu çağırmış olacaz.
-            // yapılan değişikliği kaydediyoruz veritabanına.
+            _productWriteRepository.SaveAsync();*/ // _productReadRepository ile okuduğum veriyi nasıl _productWriteRepository ile yazdırıyorum = depending enjectionda aynı scope kullanıyorlar = bu yüzden _productReadRepository'i kullandığı dbcontext ne ise bunu talep eden _productWriteRepository'de aynı instance'yi elde edecektir. o yüzden biz datayı elde ettiğimiz dbcontext üzerinden SaveAsync() fonksiyonunu çağırmış olacaz.
+                                                   // yapılan değişikliği kaydediyoruz veritabanına.
+
+            /*
+            await  _productWriteRepository.AddAsync(new() { Name = "D Product", Price = 1.600F, Stock = 20, CreatedDate = DateTime.UtcNow }); // Id verirsem alır ; vermezsem kendisi verir arka planda.
+            await _productWriteRepository.SaveAsync();
+            */
+            /*
+            var customerId = Guid.NewGuid();
+            await _customerWriteRepository.AddAsync(new() { Id = customerId ,Name="Muhiddin"});
+
+            await _orderWriteRepository.AddAsync(new() { Description = "bla bla bla", Address = "Ankara, Çankaya", CustomerId = customerId });
+            await _orderWriteRepository.AddAsync(new() { Description = "bla bla bla 2", Address = "Ankara, Pursaklar", CustomerId = customerId });
+            await _orderWriteRepository.SaveAsync(); //burda biz _orderWriteRepository ine SaveAsync() yapsakda arkada scope olarak aynı dbconteci kullandıklarından hepsine işleyip  _customerWriteRepository içinde ekleme işlemi gerçekleşecektir.
+            */
+
+            Order order = await _orderReadRepository.GetByIdAsync("bcb19f78-62fa-405d-a5ba-94c7b09552e0");
+            order.Address = "İstanbul";
+            await _orderWriteRepository.SaveAsync();
         }
 
         [HttpGet("{id}")]


### PR DESCRIPTION
…en sağlamak adına her entityde olan createdDate ve bugün eklediğmiz UpdatedDate alanlarını (Base Entiyde bu alanlar)  = interceptor yöntemi ile projede ekleme güncelleme işlemleri yapıldığında araya girip = biz vermesekde ekleme ve güncellemede otomatikmen kendisi o alanlara bugünn tarihini verecek şekilde ayarladık = bunu persistence katmanında dbcontextin içinde yapıyoruz : yaptığımız yer ise EF k'ün SaveChanges fonksiyonunu override ederek = ortasına girerek yapıyoruz. işimiz bittikten sonra SaveChanges devam ediyor = böyle EF ile interceptor yapmış oluyoruz. == böylece artık veri eklerken createdate alanını doldurmamıza gerek yok doldursakda zaten yine intercepter ile savachanges fonksiyonunda tekrar doldurulacaktır , aynı işlem update işlemlerindede geçerlidir update işlemleride updatData alanı düzenleniyor farklı olarak.

Ek olarak databaseyi sildik - persistence katmanındaki migrationu silip tekrar geri komutlarla migrationu ve veritbanını oluşturduk.